### PR TITLE
Correction for Kodi 20.

### DIFF
--- a/library.py
+++ b/library.py
@@ -8,7 +8,7 @@ import xbmcgui
 import xbmcplugin
 import urllib
 import utils
-from collections import Mapping
+from collections.abc import Mapping
 from skylink import StreamNotResolvedException
 
 _url = sys.argv[0]

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 import xbmcplugin
+import xbmcvfs
 import replay
 import live
 import library
@@ -14,7 +15,7 @@ import datetime
 
 _id = int(sys.argv[1])
 _addon = xbmcaddon.Addon()
-_profile = utils.dec_utf8(xbmc.translatePath(_addon.getAddonInfo('profile')))
+_profile = utils.dec_utf8(xbmcvfs.translatePath(_addon.getAddonInfo('profile')))
 _user_name = xbmcplugin.getSetting(_id, 'username')
 _password = xbmcplugin.getSetting(_id, 'password')
 _provider = 'skylink.sk' if int(xbmcplugin.getSetting(_id, 'provider')) == 0 else 'skylink.cz'

--- a/replay.py
+++ b/replay.py
@@ -3,7 +3,7 @@
 # Created on: 11.4.2019
 import sys, os, io
 import inputstreamhelper
-import xbmc, xbmcaddon, xbmcgui, xbmcplugin
+import xbmc, xbmcaddon, xbmcgui, xbmcplugin, xbmcvfs
 import urllib
 import datetime
 import utils
@@ -12,7 +12,7 @@ from skylink import StreamNotResolvedException
 _url = sys.argv[0]
 _handle = int(sys.argv[1])
 _addon = xbmcaddon.Addon()
-_profile = xbmc.translatePath(_addon.getAddonInfo('profile'))
+_profile = xbmcvfs.translatePath(_addon.getAddonInfo('profile'))
 _python3 = sys.version_info[0] >= 3
 
 REPLAY_GAP = 5  # gap after program ends til it shows in replay
@@ -145,7 +145,7 @@ def replay(sl, locId, duration, lastLocId):
         xbmcgui.Dialog().ok(_addon.getAddonInfo('name'), _addon.getLocalizedString(e.id))
         xbmcplugin.setResolvedUrl(_handle, False, xbmcgui.ListItem())
         return
-    
+
     if info:
         is_helper = inputstreamhelper.Helper(info['protocol'], drm=info['drm'])
         if is_helper.check_inputstream():

--- a/service.py
+++ b/service.py
@@ -8,6 +8,7 @@ import logger
 import skylink
 import xbmc
 import xbmcaddon
+import xbmcvfs
 import utils
 
 
@@ -57,7 +58,7 @@ class SkylinkMonitor(xbmc.Monitor):
 
         _username = self._addon.getSetting('username')
         _password = self._addon.getSetting('password')
-        _profile = xbmc.translatePath(self._addon.getAddonInfo('profile'))
+        _profile = xbmcvfs.translatePath(self._addon.getAddonInfo('profile'))
         _provider = 'skylink.sk' if int(self._addon.getSetting('provider')) == 0 else 'skylink.cz'
         _pin_protected_content = 'false' != self._addon.getSetting('pin_protected_content')
         sl = skylink.Skylink(_username, _password, _profile, _provider, _pin_protected_content)

--- a/skins.py
+++ b/skins.py
@@ -14,15 +14,15 @@ import random
 SKINS = {'skin.estuary':'Estuary','skin.confluence':'Confluence'}
 
 def cleanup(copy_settings, destination, destsettings):
-    shutil.rmtree(xbmc.translatePath(destination))
+    shutil.rmtree(xbmcvfs.translatePath(destination))
     if copy_settings:
-        shutil.rmtree(xbmc.translatePath(destsettings))
+        shutil.rmtree(xbmcvfs.translatePath(destsettings))
 
 def modify():
     __language__ = xbmcaddon.Addon(id='plugin.video.sl').getLocalizedString
     if not xbmcgui.Dialog().yesno(xbmc.getLocalizedString(19194), __language__(30372)):
         return
-    
+
     skin = xbmc.getSkinDir() #simplified skin detection
     if skin not in SKINS:
         xbmcgui.Dialog().ok(__language__(30373), __language__(30374))
@@ -43,9 +43,9 @@ def modify():
         copy_settings = xbmcgui.Dialog().yesno(SKINS[skin], __language__(30376))
     else:
         copy_settings = False
-    
+
     try:
-        shutil.copytree(xbmc.translatePath('special://skin'), xbmc.translatePath(destination))
+        shutil.copytree(xbmcvfs.translatePath('special://skin'), xbmcvfs.translatePath(destination))
         #alter copy addon.xml
         with closing(xbmcvfs.File(destination + '/addon.xml')) as f:
             addonxml = f.read()
@@ -55,7 +55,7 @@ def modify():
             f.write(addonxml)
         if copy_settings:
             #TODO special://profile
-            shutil.copytree(xbmc.translatePath('special://userdata/addon_data/' + skin), xbmc.translatePath(destsettings))
+            shutil.copytree(xbmcvfs.translatePath('special://userdata/addon_data/' + skin), xbmcvfs.translatePath(destsettings))
 
         #update language
         enpo = destination + '/language/resource.language.en_gb/strings.po'
@@ -67,13 +67,13 @@ def modify():
             skstrings = f.read()
         with closing(xbmcvfs.File(czpo)) as f:
             czstrings = f.read()
-        
+
         newId = str(random.randint(31000,31999))
         newIdString = '"#' + newId + '"'
         while newIdString in enstrings or newIdString in skstrings or newIdString in czstrings:
             newId = str(random.randint(31000,31999))
             newIdString = '"#' + newId + '"'
-        
+
         enstrings += '\nmsgctxt ' + newIdString + '\nmsgid "Skylink Archive"\nmsgstr "Skylink Archive"\n'
         skstrings += '\nmsgctxt ' + newIdString + '\nmsgid "Skylink Archive"\nmsgstr "Skylink Archív"\n'
         czstrings += '\nmsgctxt ' + newIdString + '\nmsgid "Skylink Archive"\nmsgstr "Skylink Archiv"\n'
@@ -97,7 +97,7 @@ def modify():
                 xbmcgui.Dialog().ok(SKINS[skin], __language__(30377))
                 return
             content = content[0]
-            
+
             toRemove = []
             for item in content:
                 for child in item:
@@ -121,7 +121,7 @@ def modify():
 
             with closing(xbmcvfs.File(xmlfile, 'w')) as f:
                 f.write(ET.tostring(root,encoding="utf-8"))
-            
+
         elif skin == 'skin.confluence':
             xmlfile = destination + '/720p/IncludesHomeMenuItems.xml'
             with closing(xbmcvfs.File(xmlfile)) as f:
@@ -137,7 +137,7 @@ def modify():
                 xbmcgui.Dialog().ok(SKINS[skin], __language__(30377))
                 return
             content = content[0]
-            
+
             toRemove = []
             for control in content:
                 for child in control:


### PR DESCRIPTION
[EN]: Solves following problem with Skylink LiveTV plugin in Kodi 20 - caused by https://github.com/xbmc/xbmc/pull/19301:
[CZ]: Řeší následující problém se Skylink LiveTV pluginem v Kodi 20 - kvůli https://github.com/xbmc/xbmc/pull/19301:

```
error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <class 'AttributeError'>
    Error Contents: module 'xbmc' has no attribute 'translatePath'
    Traceback (most recent call last):
      File "/home/kodi/.kodi/addons/plugin.video.sl/service.py", line 134, in <module>
        monitor.tick()
      File "/home/kodi/.kodi/addons/plugin.video.sl/service.py", line 113, in tick
        self.update()
      File "/home/kodi/.kodi/addons/plugin.video.sl/service.py", line 60, in update
        _profile = xbmc.translatePath(self._addon.getAddonInfo('profile'))
    AttributeError: module 'xbmc' has no attribute 'translatePath'
    -->End of Python script error report<--
                                                   
error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
    Error Type: <class 'AttributeError'>
    Error Contents: module 'xbmc' has no attribute 'translatePath'
    Traceback (most recent call last):
      File "/home/kodi/.kodi/addons/plugin.video.sl/main.py", line 9, in <module>
        import replay
      File "/home/kodi/.kodi/addons/plugin.video.sl/replay.py", line 15, in <module>
        _profile = xbmc.translatePath(_addon.getAddonInfo('profile'))
    AttributeError: module 'xbmc' has no attribute 'translatePath'
    -->End of Python script error report<--
```