### PR TITLE
Corrected broken EPG, when description is empty.

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="plugin.video.sl" version="1.7.4" name="Skylink Live TV" provider-name="Sorien, cache-sk">
+<addon id="plugin.video.sl" version="1.7.5" name="Skylink Live TV" provider-name="Sorien, cache-sk">
 <requires>
   <import addon="xbmc.python" version="3.0.0"/>
   <import addon="script.module.requests" version="2.18.4"/>
@@ -19,6 +19,10 @@
   <forum>https://www.xbmc-kodi.cz/prispevek-skylink-livetv-addon-beta</forum>
   <source>https://github.com/Sorien/plugin.video.sl</source>
   <news>
+[B]1.7.5[/B]
+- oprava generování EPG, když je description (či jiný field) prázdný
+[B]1.7.4[/B]
+- oprava pro Kodi 20 - kvůli xbmc/xbmc#19301
 [B]1.7.3[/B]
 - fix pre novy stream server blokujuci kodi
 [B]1.7.2[/B]

--- a/exports.py
+++ b/exports.py
@@ -11,7 +11,9 @@ html_escape_table = {
 
 
 def html_escape(text):
-    return "".join(html_escape_table.get(c, c) for c in text)
+    if text is not None:
+        return "".join(html_escape_table.get(c, c) for c in text)
+    return ""
 
 
 def logo_id(title):

--- a/exports.py
+++ b/exports.py
@@ -70,9 +70,9 @@ def create_epg(channels, epg, path):
                         file.write(u'<desc>%s</desc>\n' % html_escape(p['description']))
                     if 'cover' in p:
                         file.write(u'<icon src="%s"/>\n' % html_escape(p['cover']))
-                    if 'genres' in p and len(p['genres']) > 0:
+                    if 'genres' in p and not p['genres'] is None and len(p['genres']) > 0:
                         file.write('<category>%s</category>\n' % html_escape(', '.join(p['genres'])))
-                    if 'credits' in p and len(p['credits']) > 0:
+                    if 'credits' in p and not p['credits'] is None and len(p['credits']) > 0:
                         file.write(u'<credits>\n')
                         for cr in p['credits']:
                             if 'p' in cr:

--- a/skylink.py
+++ b/skylink.py
@@ -157,7 +157,7 @@ class Skylink:
 
             self._data.secret = data['secret']
             self._data.id = data['id']
-            
+
             self._store_session()
         except:
             self._data.clear()
@@ -246,9 +246,9 @@ class Skylink:
 
         stream = res.json()
 
-        if not 'url' in stream or not 'drm' in stream: 
+        if not 'url' in stream or not 'drm' in stream:
             raise StreamNotResolvedException()
-           
+
         mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA}
         str_mpd_headers = self._headers_str(mpd_headers)
         drm_la_headers = {'Origin': self._url, 'Referer': self._url, 'Content-Type': 'application/octet-stream',
@@ -260,8 +260,8 @@ class Skylink:
             'drm': 'com.widevine.alpha',
             'key': stream['drm']['laurl'] + '|' + self._headers_str(drm_la_headers) + '|R{SSM}|'
         }
-        
-        
+
+
 
     def epg(self, channels, from_date, to_date, recalculate=True):
         """Returns EPG data
@@ -296,7 +296,10 @@ class Skylink:
 
             for data in epg_info:
                 if 'description' in data:
-                    data['description'] = data['description'].strip()
+                    if not data['description'] is None:
+                        data['description'] = data['description'].strip()
+                    else:
+                        data['description'] = '...'
                 if 'cover' in data:
                     # url in web page - https://m7cz.solocoo.tv/m7cziphone/mmchan/mpimages/447x251/_hash_.jpg
                     # url in data - mmchan/mpimages/_hash_.jpg
@@ -340,10 +343,10 @@ class Skylink:
 
         stream = res.json()
 
-        if not 'url' in stream or not 'drm' in stream: 
+        if not 'url' in stream or not 'drm' in stream:
             raise StreamNotResolvedException()
-           
-        mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA, 
+
+        mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA,
                        'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
         str_mpd_headers = self._headers_str(mpd_headers)
         drm_la_headers = {'Origin': self._url, 'Referer': self._url, 'Content-Type': 'application/octet-stream',
@@ -405,10 +408,10 @@ class Skylink:
         except:
             raise StreamNotResolvedException({'error':'not json'})
 
-        if not 'url' in stream or not 'drm' in stream: 
+        if not 'url' in stream or not 'drm' in stream:
             raise StreamNotResolvedException({'error':'not valid'})
-           
-        mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA, 
+
+        mpd_headers = {'Origin': self._url, 'Referer': self._url, 'User-Agent': UA,
                        'Sec-Fetch-Mode': 'cors', 'Sec-Fetch-Site': 'same-origin'}
         str_mpd_headers = self._headers_str(mpd_headers)
         drm_la_headers = {'Origin': self._url, 'Referer': self._url, 'Content-Type': 'application/octet-stream',


### PR DESCRIPTION
[EN]: EPG was broken, when downloaded json contained empty description. It was not possible to run such program entry. Note: correction is small (line 299), rest are just trimmed white spaces.
[CZ]: EPG bylo rozbité, pokud info o pořadu obsahovalo prázdnou položku description. Nebylo možné spustit takové pořady. Pozn. oprava je malá (ř. 299), ostatní je ořez whitespace.

```python
2023-05-23 20:40:53.662 T:24312   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: 'NoneType' object has no attribute 'strip'
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/plugin.video.sl/main.py", line 141, in <module>
                                                       replay.router(args, skylink.Skylink(_user_name, _password, _profile, _provider, _pin_protected_content))
                                                     File "/storage/.kodi/addons/plugin.video.sl/replay.py", line 181, in router
                                                       programs(sl, args['stationid'][0], args['channel'][0], int(args['day'][0]) if 'day' in args else 0, 'first' in args)
                                                     File "/storage/.kodi/addons/plugin.video.sl/replay.py", line 95, in programs
                                                       epg = utils.call(sl, lambda: sl.epg([{'stationid': stationid}], from_date, to_date, False))
                                                     File "/storage/.kodi/addons/plugin.video.sl/utils.py", line 82, in call
                                                       result = fn()
                                                     File "/storage/.kodi/addons/plugin.video.sl/replay.py", line 95, in <lambda>
                                                       epg = utils.call(sl, lambda: sl.epg([{'stationid': stationid}], from_date, to_date, False))
                                                     File "/storage/.kodi/addons/plugin.video.sl/skylink.py", line 328, in epg
                                                       result.append({channel_id: tidy_epg(res[channel_id])})
                                                     File "/storage/.kodi/addons/plugin.video.sl/skylink.py", line 299, in tidy_epg
                                                       data['description'] = data['description'].strip()
                                                   AttributeError: 'NoneType' object has no attribute 'strip'
                                                   -->End of Python script error report<--

``` 

Please bump version after merging of this PR.