### PR TITLE
Ubuntu runner 18.04->22.04 for Leia syncer.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
[EN]: Upgraded Ubuntu runner to 22.04 for Leia synchronizing GitHub workflow script. [See Ubuntu runner deprecation](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)
[CZ]:  Navýšení verze Github workflow image na Ubuntu 22.04. Mělo by to zprovoznit build pro Leia branch. [Viz též Ubuntu runner deprecation](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)